### PR TITLE
Add egress rule for Bastion EC2 instance, allowing Session manager connection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,15 @@ resource "aws_security_group" "this" {
   vpc_id = var.vpc_id
 }
 
+resource "aws_security_group_rule" "session_manager_connect" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.this.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 /*
  * = Instance Setup
  */


### PR DESCRIPTION
Burde bastion-modulen hatt en egress-regel på security-gruppen sin som tillot kommunikasjon utover? Den har IAM-policyen AmazonSSMManagedInstanceCore , men den "funker ikke" hvis den ikke har egress-regler som tillater den å snakke med ec2messages.region.amazonaws.com, ssm.region.amazonaws.com og ssmmessages.region.amazonaws.com

https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-prerequisites.html
![image](https://github.com/nsbno/terraform-aws-bastion/assets/33457035/e9e66066-9550-48a0-ad6c-f3b593fd1730)
