### PR TITLE
Bump AWS AMI to Amazon Linux 2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ data "aws_ami" "amazon_linux" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-hvm*"]
+    values = ["amzn2-ami-hvm*"]
   }
 }
 


### PR DESCRIPTION
Amazon Linux 1 AMIet døde visst i januar og er nå ikke tilgjengelig lenger 😅 Det knekker deployments i `-aws`-repoet vårt i alle miljøer.

Bumper til Amazon Linux 2. 