### PR TITLE
Graviton!

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,10 @@ data "aws_ami" "amazon_linux" {
     name   = "name"
     values = ["amzn2-ami-hvm*"]
   }
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
 }
 
 resource "aws_iam_instance_profile" "this" {


### PR DESCRIPTION
`aws_ami` valgte ikke automagisk ARM-arkitektur som trengs for `t4g`  💥 